### PR TITLE
Install Maven with JDK

### DIFF
--- a/commands/install-jdk-with-maven-ubuntu/run.sh
+++ b/commands/install-jdk-with-maven-ubuntu/run.sh
@@ -20,3 +20,4 @@ apt update
 apt upgrade -y
 apt install openjdk-17-jdk -y
 export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+apt install maven

--- a/commands/install-jdk-with-maven-ubuntu/run.sh
+++ b/commands/install-jdk-with-maven-ubuntu/run.sh
@@ -20,4 +20,4 @@ apt update
 apt upgrade -y
 apt install openjdk-17-jdk -y
 export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-apt install maven
+apt install maven -y

--- a/commands/install-jdk-with-maven-ubuntu/sd-command.yaml
+++ b/commands/install-jdk-with-maven-ubuntu/sd-command.yaml
@@ -3,7 +3,7 @@ name: install-jdk-ubuntu
 version: '1.0.0'
 description: Install JDK 17
 usage: |
-  sd-cmd exec paion-data/install-jdk-ubuntu@latest
+  sd-cmd exec paion-data/install-jdk-with-maven-ubuntu@latest
 maintainer: jingjinghu@paion-data.dev
 format: binary
 binary:


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

- JDK often runs in a Maven project. We will make it an opinionated setup to bind maven with JDK in our CI/CD

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [ ] Documentation
