### PR TITLE
Do not publish template in PR

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -23,7 +23,7 @@ jobs:
     environment:
       SD_TEMPLATE_PATH: templates/react-app-alicloud-sd-template.yaml
   react-app-template-publish:
-    requires: react-app-template-validate
+    requires: [~commit, react-app-template-validate]
     steps:
       - install: npm install -g screwdriver-template-main
       - publish: template-publish --tag latest
@@ -38,7 +38,7 @@ jobs:
     environment:
       SD_TEMPLATE_PATH: templates/kong-api-gateway-sd-template.yaml
   kong-api-gateway-template-publish:
-    requires: kong-api-gateway-template-validate
+    requires: [~commit, kong-api-gateway-template-validate]
     steps:
       - install: npm install -g screwdriver-template-main
       - publish: template-publish --tag latest
@@ -50,7 +50,7 @@ jobs:
     steps:
       - validate: sd-cmd validate -f commands/install-hashicorp-packer-ubuntu/sd-command.yaml
   publish-install-hashicorp-packer-ubuntu:
-    requires: [validate-install-hashicorp-packer-ubuntu]
+    requires: [~commit, validate-install-hashicorp-packer-ubuntu]
     steps:
       - publish: sd-cmd publish -f commands/install-hashicorp-packer-ubuntu/sd-command.yaml -t latest
 
@@ -59,25 +59,25 @@ jobs:
     steps:
       - validate: sd-cmd validate -f commands/install-hashicorp-terraform-ubuntu/sd-command.yaml
   publish-install-hashicorp-terraform-ubuntu:
-    requires: [validate-install-hashicorp-terraform-ubuntu]
+    requires: [~commit, validate-install-hashicorp-terraform-ubuntu]
     steps:
       - publish: sd-cmd publish -f commands/install-hashicorp-terraform-ubuntu/sd-command.yaml -t latest
 
-  validate-install-jdk-ubuntu:
+  validate-install-jdk-with-maven-ubuntu:
     requires: [~pr, ~commit]
     steps:
-      - validate: sd-cmd validate -f commands/install-jdk-ubuntu/sd-command.yaml
-  publish-install-jdk-ubuntu:
-    requires: [validate-install-jdk-ubuntu]
+      - validate: sd-cmd validate -f commands/install-jdk-with-maven-ubuntu/sd-command.yaml
+  publish-install-jdk-with-maven-ubuntu:
+    requires: [~commit, validate-install-jdk-with-maven-ubuntu]
     steps:
-      - publish: sd-cmd publish -f commands/install-jdk-ubuntu/sd-command.yaml -t latest
+      - publish: sd-cmd publish -f commands/install-jdk-with-maven-ubuntu/sd-command.yaml -t latest
 
   validate-install-maven-ubuntu:
     requires: [~pr, ~commit]
     steps:
       - validate: sd-cmd validate -f commands/install-maven-ubuntu/sd-command.yaml
   publish-install-maven-ubuntu:
-    requires: [validate-install-maven-ubuntu]
+    requires: [~commit, validate-install-maven-ubuntu]
     steps:
       - publish: sd-cmd publish -f commands/install-maven-ubuntu/sd-command.yaml -t latest
 
@@ -86,7 +86,7 @@ jobs:
     steps:
       - validate: sd-cmd validate -f commands/install-node/sd-command.yaml
   publish-install-node:
-    requires: [validate-install-node]
+    requires: [~commit, validate-install-node]
     steps:
       - publish: sd-cmd publish -f commands/install-node/sd-command.yaml -t latest
 
@@ -95,6 +95,6 @@ jobs:
     steps:
       - validate: sd-cmd validate -f commands/install-python/sd-command.yaml
   publish-install-python:
-    requires: [validate-install-python]
+    requires: [~commit, validate-install-python]
     steps:
       - publish: sd-cmd publish -f commands/install-python/sd-command.yaml -t latest


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Fixed PR build error by turning-off publish job, because only default branch is allowed to run publish:

  ```console
  03:34:47 $ template-publish --tag latest
  03:34:48 Error: 403 Reason "Not allowed to publish this template"
  03:34:48     at throwError (/usr/local/lib/node_modules/screwdriver-template-main/node_modules/screwdriver-request/index.js:14:17)
  03:34:48     at /usr/local/lib/node_modules/screwdriver-template-main/node_modules/screwdriver-request/index.js:62:28
  03:34:48     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  03:34:48   statusCode: 403,
  03:34:48   code: 'ERR_NON_2XX_3XX_RESPONSE'
  03:34:48 }
  ```

- Fixed `master` publish error due to [unupdated name](https://github.com/paion-data/screwdriver-marketplace/pull/9)

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [ ] Documentation
